### PR TITLE
chore: update release workflow to use trusted verifier

### DIFF
--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -23,7 +23,9 @@ jobs:
           run: pip install commitizen
         
         - name: Check commit history
-          run: cz check --rev-range $(git rev-list --all --reverse | head -1)..HEAD
+          run: |
+            BASE_COMMIT=$(git merge-base HEAD ${{ github.base_ref }})
+            cz check --rev-range $BASE_COMMIT..HEAD
 
         - name: Check PR Title
           env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,28 +5,17 @@ on:
     types: [released]
 
 jobs:
-  deploy:
-
+  pypi-publish:
+    name: upload release to PyPI
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+      # retrieve your distributions here
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[release]
-        
-    - name: Build
-      run: python setup.py sdist bdist_wheel
-
-    - name: Publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: twine upload dist/* --verbose
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1      


### PR DESCRIPTION
### What I did

Update CI process to support trusted verifiers for pypy integration.

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [X] New test cases have been added and are passing
- [X] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
